### PR TITLE
Introducing app grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I used ubuntu 14.04 as base when installing and had to additional java-8 repo
 `sudo add-apt-repository ppa:openjdk-r/ppa`
 
 download libprotobuf7 from http://launchpadlibrarian.net/160197953/libprotobuf7_2.4.1-3ubuntu4_amd64.deb
-and install 
+and install
 
 `sudo dpkg -i ./libprotobuf7_2.4.1-3ubuntu4_amd64.deb`
 
@@ -79,6 +79,12 @@ source ../venv/bin/activate
 
 ### Install all the dependencies
 `pyb install_dependencies`
+
+### Install RMQ pre-reqs for unit test using mock backend
+`sudo apt-get install rabbitmq-server`
+`sudo rabbitmqctl add_user hydra hydra`
+`sudo rabbitmqctl set_user_tags hydra administrator`
+`sudo rabbitmqctl set_permissions hydra ".*" ".*" ".*`
 
 ### Install the hydra package
 `pyb install`

--- a/build.py
+++ b/build.py
@@ -53,6 +53,7 @@ def set_properties(project):
     project.set_property('flake8_verbose_output', True)
     project.set_property('flake8_break_build', True)
     project.set_property('flake8_include_test_sources', True)
+    project.set_property('flake8_max_line_length', 130)
 
     project.set_property('publish_command','./make_test_exec.sh')
     project.set_property('publish_propagate_stderr', True)

--- a/src/main/python/hydra/kraken/__init__.py
+++ b/src/main/python/hydra/kraken/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'AbdullahS'

--- a/src/main/python/hydra/kraken/kraken.py
+++ b/src/main/python/hydra/kraken/kraken.py
@@ -1,0 +1,56 @@
+__author__ = 'AbdullahS'
+
+import sys
+from pprint import pprint, pformat  # NOQA
+from optparse import OptionParser
+import logging
+from hydra.lib import util
+from hydra.lib.h_analyser import HAnalyser
+from hydra.lib.runtestbase import RunTestBase
+
+try:
+    # Python 2.x
+    from ConfigParser import ConfigParser
+except ImportError:
+    # Python 3.x
+    from configparser import ConfigParser
+
+l = util.createlogger('kraken', logging.INFO)
+# l.setLevel(logging.DEBUG)
+
+class Kraken(RunTestBase):
+    def __init__(self, options, runtest=True, mock=False):
+        self.options = options
+
+        self.config = ConfigParser()
+        RunTestBase.__init__(self, 'kraken', self.options, self.config, startappserver=runtest, mock=mock)
+
+    def release_the_kraken(self):
+        """
+        soon...
+        """
+
+class RunTest(object):
+    def __init__(self, argv):
+        usage = ('python %prog --test_duration=<time to run test>')
+        parser = OptionParser(description='KRAKEN !!!',
+                              version="0.1", usage=usage)
+        parser.add_option("--test_duration", dest='test_duration', type='float', default=10)
+
+        (options, args) = parser.parse_args()
+        if ((len(args) != 0)):
+            parser.print_help()
+            sys.exit(1)
+        r = Kraken(options, False)
+        r.start_appserver()
+        res = r.release_the_kraken()
+        r.delete_all_launched_apps()
+        print("RES = " + pformat(res))
+        if not options.keep_running:
+            r.stop_appserver()
+        else:
+            print("Keep running is set: Leaving the app server running")
+            print("   you can use the marathon gui/cli to scale the app up.")
+            print("   after you are done press enter on this window")
+            input('>')
+            r.stop_appserver()

--- a/src/main/python/hydra/kraken/kraken.py
+++ b/src/main/python/hydra/kraken/kraken.py
@@ -5,7 +5,6 @@ from pprint import pprint, pformat  # NOQA
 from optparse import OptionParser
 import logging
 from hydra.lib import util
-from hydra.lib.h_analyser import HAnalyser
 from hydra.lib.runtestbase import RunTestBase
 
 try:
@@ -18,6 +17,7 @@ except ImportError:
 l = util.createlogger('kraken', logging.INFO)
 # l.setLevel(logging.DEBUG)
 
+
 class Kraken(RunTestBase):
     def __init__(self, options, runtest=True, mock=False):
         self.options = options
@@ -29,6 +29,7 @@ class Kraken(RunTestBase):
         """
         soon...
         """
+
 
 class RunTest(object):
     def __init__(self, argv):

--- a/src/main/python/hydra/lib/mock_backend.py
+++ b/src/main/python/hydra/lib/mock_backend.py
@@ -235,7 +235,6 @@ class MockMarathonIF(object):
                 l.info("Waiting for app [%s] to launch", app)
 
     def scale_app(self, app, scale):
-        # TODO: (AbdullahS) See if it makes sense to implement scale_app
         l.info("Mock scale app")
         scale_app_name = app + "-scale"
         attr = self.app_attr[app][0]

--- a/src/main/python/hydra/lib/mock_backend.py
+++ b/src/main/python/hydra/lib/mock_backend.py
@@ -66,6 +66,7 @@ class MockMarathonIF(object):
         self.port_index = 0
         self.generate_env_ports()
         self.list_apps = {}
+        self.app_attr = {}
 
     def generate_env_ports(self):
         """
@@ -148,6 +149,8 @@ class MockMarathonIF(object):
         app_id : unique app id
         attr   : hydra MarathonApp instance, creates all app attributes
         """
+        if app_id not in self.app_attr:
+            self.app_attr[app_id] = attr
         # Prepare process data
         cmd = attr.cmd
         requested_ports = len(attr.ports)
@@ -169,7 +172,7 @@ class MockMarathonIF(object):
             self.port_index += 1
 
         # Init app info
-        app_info = AppInfo()
+        self.app_info = AppInfo()
         myenv["mock"] = "true"
         app_info.cmgr.add_child(app_id, cmd, cwd, myenv)
         app_info.cmgr.launch_children(ports=curr_ports)
@@ -219,6 +222,8 @@ class MockMarathonIF(object):
 
     def scale_app(self, app, scale):
         # TODO: (AbdullahS) See if it makes sense to implement scale_app
+        attr = self.app_attr[app]
+        self.create_app()
         return True
 
 

--- a/src/main/python/hydra/lib/mock_backend.py
+++ b/src/main/python/hydra/lib/mock_backend.py
@@ -73,10 +73,6 @@ class MockMarathonIF(object):
         Generates a list of random numbers
         to be passed on to child processes as ports
 
-        TODO (AbdullahS): There is no guarantee that
-                          generated ports will be available
-                          at OS level as well. See if this can
-                          be improved.
         """
         self.env_ports = []
         for x in range(self.total_ports):
@@ -235,7 +231,6 @@ class MockMarathonIF(object):
                 l.info("Waiting for app [%s] to launch", app)
 
     def scale_app(self, app, scale):
-        # TODO: (AbdullahS) See if it makes sense to implement scale_app
         l.info("Mock scale app")
         scale_app_name = app + "-scale"
         attr = self.app_attr[app][0]

--- a/src/main/python/hydra/lib/runtestbase.py
+++ b/src/main/python/hydra/lib/runtestbase.py
@@ -307,8 +307,6 @@ class RunTestBase(BoundaryRunnerBase):
             info = self.apps[name]['ip_port_map'][task_id]
             port = info[0]
             ip = info[1]
-            l.info(port)
-            l.info(ip)
             ha_sub = HAnalyser(ip, port, task_id)
             # Signal it to reset all client stats
             ha_sub.reset_stats()
@@ -353,12 +351,13 @@ class RunTestBase(BoundaryRunnerBase):
             temp_dict[g_name] = []
         for item in remove_list:
             del self.apps[name]['ip_port_map'][item]
-            if self.app_group:
-                for g_name, g_list in self.app_group.items():
-                    if item in g_list:
-                        temp_dict[g_name].append(item)
+            for g_name, g_list in self.app_group.items():
+                l.info("Checking if bad client[%s] is in group[%s]", item, g_name)
+                if item in g_list:
+                    temp_dict[g_name].append(item)
         for g_name, bad_list in temp_dict.items():
             for bad_client in bad_list:
+                l.info("Removing client [%s] from group [%s]", bad_client, g_name)
                 self.app_group[g_name].remove(bad_client)
 
     def refresh_app_info(self, name):

--- a/src/main/python/hydra/lib/runtestbase.py
+++ b/src/main/python/hydra/lib/runtestbase.py
@@ -359,6 +359,7 @@ class RunTestBase(BoundaryRunnerBase):
             for bad_client in bad_list:
                 l.info("Removing client [%s] from group [%s]", bad_client, g_name)
                 self.app_group[g_name].remove(bad_client)
+                self.all_task_ids[g_name].remove(bad_client)
 
     def refresh_app_info(self, name):
         """ Refresh all the ip-port map for the application

--- a/src/main/python/hydra/lib/runtestbase.py
+++ b/src/main/python/hydra/lib/runtestbase.py
@@ -359,7 +359,7 @@ class RunTestBase(BoundaryRunnerBase):
             for bad_client in bad_list:
                 l.info("Removing client [%s] from group [%s]", bad_client, g_name)
                 self.app_group[g_name].remove(bad_client)
-                self.all_task_ids[g_name].remove(bad_client)
+                self.all_task_ids[name].remove(bad_client)
 
     def refresh_app_info(self, name):
         """ Refresh all the ip-port map for the application

--- a/src/main/python/hydra/rmqtest/runtest.py
+++ b/src/main/python/hydra/rmqtest/runtest.py
@@ -63,7 +63,9 @@ class RunTestRMQ(RunTestBase):
                                   msg_requested_rate=self.options.msg_rate)
         l.info("PUB server updated")
 
-        self.reset_all_app_stats(self.rmqsub)
+        # Pass signals in groups of apps
+        for g_index in range(self.total_app_groups):
+            self.reset_app_group_stats(self.rmqsub, g_index)
 
         # Signal message sending
         l.info("Sending signal to PUB to start sending all messages..")
@@ -200,21 +202,19 @@ class RunTestRMQ(RunTestBase):
 
     def launch_rmq_sub(self):
         l.info("Launching the sub app")
+        self.total_app_groups = self.options.total_sub_apps / self.options.apps_in_group
+        self.options.total_sub_apps = self.options.total_sub_apps / self.options.apps_in_group
         constraints = []
         # Use cluster 1 for launching the SUB
         if 1 in self.mesos_cluster:
             constraints.append(self.app_constraints(field=self.mesos_cluster[1]['cat'],
                                                     operator='CLUSTER', value=self.mesos_cluster[1]['match']))
-        self.create_hydra_app(name=self.rmqsub, app_path='hydra.rmqtest.rmq_sub.run10',
+        self.create_hydra_app_group(name=self.rmqsub, app_path='hydra.rmqtest.rmq_sub.run10',
                               app_args='%s' % (self.pub_ip),
-                              cpus=0.01, mem=32,
+                              cpus=0.01, mem=32, apps_in_group=self.options.apps_in_group,
+                              total_apps=self.options.total_sub_apps,
                               ports=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                               constraints=constraints)
-        # scale
-        self.scale_sub_app()
-
-    def scale_sub_app(self):
-        self.scale_and_verify_app(self.rmqsub, self.options.total_sub_apps)
 
     def delete_all_launched_apps(self):
         l.info("Deleting all launched apps")
@@ -234,7 +234,8 @@ class RunTest(object):
         parser.add_option("--test_duration", dest='test_duration', type='float', default=10)
         parser.add_option("--msg_batch", dest='msg_batch', type='int', default=100)
         parser.add_option("--msg_rate", dest='msg_rate', type='float', default=10000)
-        parser.add_option("--total_sub_apps", dest='total_sub_apps', type='int', default=100)
+        parser.add_option("--total_sub_apps", dest='total_sub_apps', type='int', default=20)
+        parser.add_option("--apps_in_group", dest='apps_in_group', type='int', default=10)
         parser.add_option("--config_file", dest='config_file', type='string', default='hydra.ini')
         parser.add_option("--keep_running", dest='keep_running', action="store_true", default=False)
 

--- a/src/main/python/hydra/rmqtest/runtest.py
+++ b/src/main/python/hydra/rmqtest/runtest.py
@@ -68,6 +68,7 @@ class RunTestRMQ(RunTestBase):
         self.create_app_group(self.rmqsub, "test-group2", apps_in_group=5)
         self.create_app_group(self.rmqsub, "test-group3", apps_in_group=5)
         l.info("Groups created")
+        self.ping_all_app_inst(self.rmqsub)
 
         # Pass signals in groups of apps
         self.reset_all_app_stats(self.rmqsub, group_name="test-group")
@@ -225,7 +226,7 @@ class RunTestRMQ(RunTestBase):
         self.scale_sub_app()
 
     def scale_sub_app(self):
-        self.scale_and_verify_app(self.rmqsub, self.options.total_sub_apps)
+        self.scale_and_verify_app(self.rmqsub, self.options.total_sub_apps, ping=False)
 
     def delete_all_launched_apps(self):
         l.info("Deleting all launched apps")

--- a/src/main/python/hydra/rmqtest/runtest.py
+++ b/src/main/python/hydra/rmqtest/runtest.py
@@ -63,9 +63,16 @@ class RunTestRMQ(RunTestBase):
                                   msg_requested_rate=self.options.msg_rate)
         l.info("PUB server updated")
 
+        # Create test groups
+        self.create_app_group(self.rmqsub, "test-group", apps_in_group=10)
+        self.create_app_group(self.rmqsub, "test-group2", apps_in_group=5)
+        self.create_app_group(self.rmqsub, "test-group3", apps_in_group=5)
+        l.info("Groups created")
+
         # Pass signals in groups of apps
-        for g_index in range(self.total_app_groups):
-            self.reset_app_group_stats(self.rmqsub, g_index)
+        self.reset_all_app_stats(self.rmqsub, group_name="test-group")
+        self.reset_all_app_stats(self.rmqsub, group_name="test-group2")
+        self.reset_all_app_stats(self.rmqsub, group_name="test-group3")
 
         # Signal message sending
         l.info("Sending signal to PUB to start sending all messages..")
@@ -209,12 +216,16 @@ class RunTestRMQ(RunTestBase):
         if 1 in self.mesos_cluster:
             constraints.append(self.app_constraints(field=self.mesos_cluster[1]['cat'],
                                                     operator='CLUSTER', value=self.mesos_cluster[1]['match']))
-        self.create_hydra_app_group(name=self.rmqsub, app_path='hydra.rmqtest.rmq_sub.run10',
-                                    app_args='%s' % (self.pub_ip),
-                                    cpus=0.01, mem=32, apps_in_group=self.options.apps_in_group,
-                                    total_apps=self.options.total_sub_apps,
-                                    ports=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                    constraints=constraints)
+        self.create_hydra_app(name=self.rmqsub, app_path='hydra.rmqtest.rmq_sub.run10',
+                              app_args='%s' % (self.pub_ip),
+                              cpus=0.01, mem=32,
+                              ports=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                              constraints=constraints)
+
+        self.scale_sub_app()
+
+    def scale_sub_app(self):
+        self.scale_and_verify_app(self.rmqsub, self.options.total_sub_apps)
 
     def delete_all_launched_apps(self):
         l.info("Deleting all launched apps")

--- a/src/main/python/hydra/rmqtest/runtest.py
+++ b/src/main/python/hydra/rmqtest/runtest.py
@@ -210,11 +210,11 @@ class RunTestRMQ(RunTestBase):
             constraints.append(self.app_constraints(field=self.mesos_cluster[1]['cat'],
                                                     operator='CLUSTER', value=self.mesos_cluster[1]['match']))
         self.create_hydra_app_group(name=self.rmqsub, app_path='hydra.rmqtest.rmq_sub.run10',
-                              app_args='%s' % (self.pub_ip),
-                              cpus=0.01, mem=32, apps_in_group=self.options.apps_in_group,
-                              total_apps=self.options.total_sub_apps,
-                              ports=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                              constraints=constraints)
+                                    app_args='%s' % (self.pub_ip),
+                                    cpus=0.01, mem=32, apps_in_group=self.options.apps_in_group,
+                                    total_apps=self.options.total_sub_apps,
+                                    ports=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    constraints=constraints)
 
     def delete_all_launched_apps(self):
         l.info("Deleting all launched apps")

--- a/src/main/scripts/hydra
+++ b/src/main/scripts/hydra
@@ -17,6 +17,7 @@ classPath = {
     'rmq' : 'hydra.rmqtest.runtest.RunTest',
     'rmqpub' : 'hydra.rmqtest.rmq_pub.run',
     'rmqfixed': 'hydra.rmqtest.fixed_test.run',
+    'kraken' : 'hydra.kraken.kraken.RunTest',
 }
 if len(sys.argv) < 2 or sys.argv[1] == '-h' or sys.argv[1] == '--help':
     print("Options are %s " % sys.argv[0] + " " + pformat(classPath.keys()))

--- a/src/unittest/python/rmq_local_tests.py
+++ b/src/unittest/python/rmq_local_tests.py
@@ -35,7 +35,8 @@ class RMQLocalTest(unittest.TestCase):
         setattr(options, 'test_duration', 10)
         setattr(options, 'msg_batch', 50)
         setattr(options, 'msg_rate', 1000)
-        setattr(options, 'total_sub_apps', 1)
+        setattr(options, 'total_sub_apps', 20)
+        setattr(options, 'apps_in_group', 10)
         # TODO: AbdullahS: see if we can get rid of config file
         #       requirement for local tests
         setattr(options, 'config_file', pwd + '/src/unittest/python/test.ini')


### PR DESCRIPTION
```
App grouping for message passing

** This commit introduces app grouping for launched hydra apps
** Each group can be sent seprate signals
** Update mock backend to enable scaling of apps
** Update rmq test to use groups as a POC
** Unit test exercises full code path

** Also add Kraken minimal skeleton (does nothing at all :) )
```
