### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Go inside Hydra cloned repo and run
 pip install pybuilder
 pyb install_dependencies --verbose
 pyb analyze
-pyb publish -x run_unit_tests
-pyb install -x run_unit_tests
+pyb publish -x run_unit_tests -x run_integration_tests -x verify
+pyb install -x run_unit_tests -x run_integration_tests -x verify
 ```
 
 Congratulations! You have installed Hydra. <\br >


### PR DESCRIPTION
The ''mesos_marathon_tests.py'' integration tests fail when using ''pyb publish -x run_unit_tests''. 
Use ''pyb publish -x run_unit_tests -x run_integration_tests -x verify'' instead.
