### PR TITLE
Discarding the master-slave language

### DIFF
--- a/src/integrationtest/python/mesos_marathon_tests.py
+++ b/src/integrationtest/python/mesos_marathon_tests.py
@@ -16,8 +16,8 @@ from hydra.lib.hydrabase import HydraBase
 tests :
  -Check connectivity to mesos
  -check connectivity to marathon
- -check number of slaves
- - check cpu/memory etc. on slave
+ -check number of subordinates
+ - check cpu/memory etc. on subordinate
  - check app server deployment
  - chack launching of app-s
  - check communication to app-s
@@ -81,8 +81,8 @@ class hydraUnitTest(unittest.TestCase):  # NOQA
         self.rt = None
 
     def test_mesos_health(self):
-        # slaveCount = self.rt.mesos.get_slave_cnt()
-        # self.assertTrue(slaveCount > 0)
+        # subordinateCount = self.rt.mesos.get_subordinate_cnt()
+        # self.assertTrue(subordinateCount > 0)
         self.assertTrue(self.rt.get_mesos_health(), "Unable to get health status from mesos")
         ver = self.rt.get_mesos_version()
         self.assertNotEqual(ver, None, "Unable to get version information from mesos")
@@ -103,9 +103,9 @@ class hydraUnitTest(unittest.TestCase):  # NOQA
         self.assertTrue(stats['mem_total_bytes'] > 0)
         self.assertTrue(stats['mem_free_bytes'] > 0)
 
-    def test_mesos_slaves(self):
-        slave_count = self.rt.get_mesos_slave_count()
-        self.assertTrue(slave_count > 0, 'No slaves detected on mesos cluster')
+    def test_mesos_subordinates(self):
+        subordinate_count = self.rt.get_mesos_subordinate_count()
+        self.assertTrue(subordinate_count > 0, 'No subordinates detected on mesos cluster')
 
     def test_marathon_connectivity(self):
         a = self.rt.ping()

--- a/src/main/python/hydra/kafkatest/maxrate_test.py
+++ b/src/main/python/hydra/kafkatest/maxrate_test.py
@@ -77,7 +77,7 @@ class RunSuitMaxRate(object):
 def Run(argv):  # NOQA
     usage = ('python %prog --c_pub --c_sub'
              ' --test_duration=<time to run test> --msg_batch=<msg burst batch before sleep>')
-    parser = OptionParser(description='kafka scale maxrate test master',
+    parser = OptionParser(description='kafka scale maxrate test main',
                           version="0.1", usage=usage)
     parser.add_option("--test_duration", dest='test_duration', type='int', default=15)
     parser.add_option("--msg_batch", dest='msg_batch', type='int', default=100)

--- a/src/main/python/hydra/kafkatest/runtest.py
+++ b/src/main/python/hydra/kafkatest/runtest.py
@@ -245,7 +245,7 @@ class RunTest(object):
                  '--acks=<server_acknowledgement> --linger_ms=<linger_ms>'
                  '--consumer_max_buffer_size=<consumer_buffer_size>')
         # Parse Command-Line options and set to default values if not specified
-        parser = OptionParser(description='kafka scale test master',
+        parser = OptionParser(description='kafka scale test main',
                               version="0.1", usage=usage)
         parser.add_option("--test_duration", dest='test_duration', type='float', default=10)
         parser.add_option("--msg_batch", dest='msg_batch', type='int', default=100)

--- a/src/main/python/hydra/lib/cli.py
+++ b/src/main/python/hydra/lib/cli.py
@@ -1,7 +1,7 @@
 """hydra cli.
 
 Usage:
-   hydra cli ls slaves
+   hydra cli ls subordinates
    hydra cli ls apps
    hydra cli ls task <app>
    hydra cli [force] stop <app>
@@ -53,9 +53,9 @@ def cli(argv):
     args = docopt(__doc__, argv=argv, version='hydra 0.1.0', )
     # pprint (args)
     if args['ls']:
-        if args['slaves']:
+        if args['subordinates']:
             mesos = mmapi.MesosIF(mesos_addr)
-            mesos.print_slaves()
+            mesos.print_subordinates()
         elif args['apps']:
             mt = mmapi.MarathonIF(marathon_addr, '127.0.0.1', None)
             apps = mt.get_apps()
@@ -107,7 +107,7 @@ def cli(argv):
         mt.wait_app_ready(app, scale)
 # SK:Tried to add log collection but no luck so far.
 #    elif args['logs']:
-#        path = "/tmp/mesos/slaves/"
+#        path = "/tmp/mesos/subordinates/"
 #        #11323ada-daab-4d76-8749-3113b5448bed-S0/
 #        path += "/frameworks/
 #        # #11323ada-daab-4d76-8749-3113b5448bed-0007

--- a/src/main/python/hydra/lib/mmapi.py
+++ b/src/main/python/hydra/lib/mmapi.py
@@ -159,35 +159,35 @@ class MarathonIF(object):
 class MesosIF(object):
     def __init__(self, addr):
         self.myaddr = addr
-        self.update_slaves()
+        self.update_subordinates()
 
-    def update_slaves(self):
-        r = requests.get(self.myaddr + '/master/slaves')
+    def update_subordinates(self):
+        r = requests.get(self.myaddr + '/main/subordinates')
         assert r.status_code == 200
         dt = json.loads(r.content.decode("utf-8"))
-        self.noOfSlaves = len(dt['slaves'])
-        # pprint(" Slaves Found : " + str(self.noOfSlaves))
-        self.slavesID = {}
-        self.slavesHN = {}
-        for idx in range(0, self.noOfSlaves):
-            itm = dt['slaves'][idx]
-            # l.info(" Slave [" + itm['hostname'] + " ID=" + itm['id'] +
+        self.noOfSubordinates = len(dt['subordinates'])
+        # pprint(" Subordinates Found : " + str(self.noOfSubordinates))
+        self.subordinatesID = {}
+        self.subordinatesHN = {}
+        for idx in range(0, self.noOfSubordinates):
+            itm = dt['subordinates'][idx]
+            # l.info(" Subordinate [" + itm['hostname'] + " ID=" + itm['id'] +
             #       "  CPU = " + str(itm['used_resources']['cpus']) + '/' + str(itm['unreserved_resources']['cpus']))
-            self.slavesHN[itm['hostname']] = itm
-            self.slavesID[itm['id']] = itm
+            self.subordinatesHN[itm['hostname']] = itm
+            self.subordinatesID[itm['id']] = itm
 
     def get_health(self):
-        r = requests.get(self.myaddr + '/master/state')
+        r = requests.get(self.myaddr + '/main/state')
         if (r.status_code == 200):
             return True
         return False
 
-    def get_slave_stats(self, ip, port=5051):
+    def get_subordinate_stats(self, ip, port=5051):
         """
-        Get slave statistics via mesos API
+        Get subordinate statistics via mesos API
         @args:
-        ip:      Ip of the slave
-        port:    Port that slave is listening to for requests
+        ip:      Ip of the subordinate
+        port:    Port that subordinate is listening to for requests
         """
         addr = "http://%s:%d" % (ip, port)
         # returns a list of app tasks
@@ -214,35 +214,35 @@ class MesosIF(object):
             return json.loads(r.content.decode("utf-8"))
         return None
 
-    def print_slaves(self):
-        for slaveId in self.slavesID.keys():
-            itm = self.slavesID[slaveId]
-            l.info(" Slave [" + itm['hostname'] + " ID=" + itm['id'] +
+    def print_subordinates(self):
+        for subordinateId in self.subordinatesID.keys():
+            itm = self.subordinatesID[subordinateId]
+            l.info(" Subordinate [" + itm['hostname'] + " ID=" + itm['id'] +
                    "  CPU = " + str(itm['used_resources']['cpus']) + '/' + str(itm['unreserved_resources']['cpus']))
 
-    def get_slave_cnt(self):
-        return self.noOfSlaves
+    def get_subordinate_cnt(self):
+        return self.noOfSubordinates
 
     def get_id(self, id):
-        return self.slavesID[id]
+        return self.subordinatesID[id]
 
     def get_hn(self, hn):
-        return self.slavesHN[hn]
+        return self.subordinatesHN[hn]
 
     def get_ip_from_pid(self, pid):
         return pid.split('@')[1].split(':')[0]
 
-    def get_slave_ip_from_id(self, slave_id):
-        pid = self.slavesID[slave_id]['pid']
+    def get_subordinate_ip_from_id(self, subordinate_id):
+        pid = self.subordinatesID[subordinate_id]['pid']
         return self.get_ip_from_pid(pid)
 
-    def get_slave_ip_from_hn(self, slave_hn):
-        pid = self.slavesHN[slave_hn]['pid']
+    def get_subordinate_ip_from_hn(self, subordinate_hn):
+        pid = self.subordinatesHN[subordinate_hn]['pid']
         return self.get_ip_from_pid(pid)
 
-    def get_slave_ips_from_attribute(self, attr_type, attr_value):
+    def get_subordinate_ips_from_attribute(self, attr_type, attr_value):
         ret = []
-        for host_ip, info in self.slavesHN.items():
+        for host_ip, info in self.subordinatesHN.items():
             if info["attributes"][attr_type] == attr_value:
                 ret.append(host_ip)
         return ret

--- a/src/main/python/hydra/lib/mock_backend.py
+++ b/src/main/python/hydra/lib/mock_backend.py
@@ -243,30 +243,30 @@ class MockMarathonIF(object):
 class MockMesosIF(object):
     """
     MockMesosIF class.
-    Creates a mapping of only one slave i-e localhost
+    Creates a mapping of only one subordinate i-e localhost
     """
     def __init__(self, addr):
-        self.slaves_ids = {}
-        self.slaves_hostname_info = {}
-        self.slave_count = 1
+        self.subordinates_ids = {}
+        self.subordinates_hostname_info = {}
+        self.subordinate_count = 1
         self.myaddr = addr
         self.myip = "127.0.0.1"
-        self.update_slaves()
+        self.update_subordinates()
         l.info("MockMesosIF init")
 
-    def update_slaves(self):
+    def update_subordinates(self):
         """
         Populate localhost data
         """
-        self.total_slaves = self.slave_count
-        self.slaves_hostname_info["localhost"] = self.myip
-        l.info(self.slaves_hostname_info)
+        self.total_subordinates = self.subordinate_count
+        self.subordinates_hostname_info["localhost"] = self.myip
+        l.info(self.subordinates_hostname_info)
 
-    def get_slave_ip_from_hn(self, slave_hn):
+    def get_subordinate_ip_from_hn(self, subordinate_hn):
         """
         Return ip for hostname (localhost)
 
         @args:
-        slave_hn  : slave hostname
+        subordinate_hn  : subordinate hostname
         """
-        return self.slaves_hostname_info[slave_hn]
+        return self.subordinates_hostname_info[subordinate_hn]

--- a/src/main/python/hydra/rmqtest/runtest.py
+++ b/src/main/python/hydra/rmqtest/runtest.py
@@ -246,7 +246,7 @@ class RunTest(object):
         usage = ('python %prog --test_duration=<time to run test> --msg_batch=<msg burst batch before sleep>'
                  '--msg_rate=<rate in packet per secs> --total_sub_apps=<Total sub apps to launch>'
                  '--config_file=<path_to_config_file> --keep_running')
-        parser = OptionParser(description='zmq scale test master',
+        parser = OptionParser(description='zmq scale test main',
                               version="0.1", usage=usage)
         parser.add_option("--test_duration", dest='test_duration', type='float', default=10)
         parser.add_option("--msg_batch", dest='msg_batch', type='int', default=100)

--- a/src/main/python/hydra/zmqtest/fixed_test.py
+++ b/src/main/python/hydra/zmqtest/fixed_test.py
@@ -63,7 +63,7 @@ class RunSuitFixed(object):
 def Run(argv):  # NOQA
     usage = ('python %prog --c_pub --c_sub'
              ' --test_duration=<time to run test> --msg_batch=<msg burst batch before sleep>')
-    parser = OptionParser(description='zmq scale maxrate test master',
+    parser = OptionParser(description='zmq scale maxrate test main',
                           version="0.1", usage=usage)
     parser.add_option("--test_duration", dest='test_duration', type='int', default=15)
     parser.add_option("--msg_batch", dest='msg_batch', type='int', default=100)

--- a/src/main/python/hydra/zmqtest/maxrate_test.py
+++ b/src/main/python/hydra/zmqtest/maxrate_test.py
@@ -139,7 +139,7 @@ class RunSuitMaxRate(object):
 def Run(argv):  # NOQA
     usage = ('python %prog --c_pub --c_sub'
              ' --test_duration=<time to run test> --msg_batch=<msg burst batch before sleep>')
-    parser = OptionParser(description='zmq scale maxrate test master',
+    parser = OptionParser(description='zmq scale maxrate test main',
                           version="0.1", usage=usage)
     parser.add_option("--test_duration", dest='test_duration', type='int', default=15)
     parser.add_option("--msg_batch", dest='msg_batch', type='int', default=100)

--- a/src/main/python/hydra/zmqtest/runtest.py
+++ b/src/main/python/hydra/zmqtest/runtest.py
@@ -344,7 +344,7 @@ class RunTest(object):
         usage = ('python %prog --test_duration=<time to run test> --msg_batch=<msg burst batch before sleep>'
                  '--msg_rate=<rate in packet per secs> --total_sub_apps=<Total sub apps to launch>'
                  '--config_file=<path_to_config_file> --keep_running')
-        parser = OptionParser(description='zmq scale test master',
+        parser = OptionParser(description='zmq scale test main',
                               version="0.1", usage=usage)
         parser.add_option("--test_duration", dest='test_duration', type='int', default=10)
         parser.add_option("--msg_batch", dest='msg_batch', type='int', default=100)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.